### PR TITLE
ci: Removing skipping of jshint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ ci:
   skip:
     - 'ansible-lint'
     - 'commitlint'
-    - 'jshint'
     - 'markdown-link-check'
     - 'markdownlint'
     - 'pyspelling'


### PR DESCRIPTION
jshint should run during pre-commit CI to avoid adding another GitHub Action.