### PR TITLE
ci: Ignoring URLs with %23

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -11,6 +11,10 @@
     {
       "___comment___": "ignoring SSHd ciphers",
       "pattern": "^mailto:.+@(openssh.com|libssh.org)$"
+    },
+    {
+      "___comment___": "ignoring URLs with %23 as it leads to false positives. see https://github.com/tcort/markdown-link-check/issues/264",
+      "pattern": ".+?\\%23.+?"
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
Ignoring URLs with %23, as this leads to false positives with markdown-link-check - see https://github.com/tcort/markdown-link-check/issues/264