### PR TITLE
fix: Fix ansible-lint configuration + fix assert task prefix

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,13 +6,6 @@ enable_list:
   - 'no-same-owner'
   - 'name[prefix]'
 
-kinds:
-  - yaml: '.ansible-lint'
-  - yaml: '.github/workflows/*.{yml,yaml}'
-  - yaml: '.pre-commit-config.yaml'
-  - yaml: '.yamllint'
-  - yaml: '**/*.{yml,yaml}'
-
 loop_var_prefix: '^(__|{role}_)'
 max_block_depth: 20
 offline: true

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,7 +1,7 @@
 ---
 # NOTE: _fd_quiet_assert does not impact this task, as it first needs to be ensured that it actually is
 #       properly defined
-- name: 'Ensure mandatory variables, as well as variables, which have a default value, are set (boolean)'
+- name: 'assert | Ensure mandatory variables, as well as variables, which have a default value, are set (boolean)'
   ansible.builtin.assert:
     that:
       - "lookup('ansible.builtin.vars', __t_var) is defined"
@@ -15,7 +15,7 @@
     loop_var: '__t_var'
     label: 'variable: {{ __t_var }}'
 
-- name: 'Ensure _fd_packages is defined properly'
+- name: 'assert | Ensure _fd_packages is defined properly'
   ansible.builtin.assert:
     that:
       # destination is defined for all items


### PR DESCRIPTION
The ansible-lint configuration did not detect all file kinds correctly. This caused tasks to be not interpreted as tasks but only as plain YAML files.

By removing the kinds directive, all files are detected as defined in the configuration of ansible-lint natively:
https://github.com/ansible/ansible-lint/blob/main/src/ansiblelint/config.py