### PR TITLE
ci: Pin EEs to minor versions

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -61,31 +61,31 @@ jobs:
           #
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.17.1@sha256:fa661580efb29a119489b71bc28e286a3f38bee89f312b756f3c0d4fd1df88c7'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.17'
             cache_key_suffix: 'rhel8-2.17'
             # renovate yaml: datasource=pypi
             molecule: '24.6.1'
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.16.8@sha256:22e6773b832d01602a6d822f8c947c79d46c6b932a466874776929adf39e7ed2'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.16'
             cache_key_suffix: 'rhel8-2.16'
             # renovate yaml: datasource=pypi
             molecule: '24.6.1'
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.15.11@sha256:0cda496e21c9565b00ba7e2da8c4f85e56dbdcf7a22f07749e4177ec5c106186'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.15'
             cache_key_suffix: 'rhel8-2.15'
             # renovate yaml: datasource=pypi
             molecule: '6.0.3'
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.14.13@sha256:8ae958de1fa41427b7fc972d96f5b97ff6e3d878de1dceba9de6bfd2377fb990'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.14'
             cache_key_suffix: 'rhel8-2.14'
             # renovate yaml: datasource=pypi
             molecule: '6.0.3'
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.13.10@sha256:6d7db6eebd6653c20c0e4dd93e51190001431d2183bd5435834664d39311876f'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.13'
             cache_key_suffix: 'rhel8-2.13'
             # renovate yaml: datasource=pypi
             molecule: '6.0.3'
@@ -95,7 +95,7 @@ jobs:
           #
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.17.1@sha256:396cd568af193191dca7d1ba059cfd5c5f98e20b2e96c16e2b5e4559c5178e8e'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.17'
             cache_key_suffix: 'rhel9-2.17'
             # renovate yaml: datasource=pypi
             molecule: '24.6.1'
@@ -103,7 +103,7 @@ jobs:
               - 'python-unversioned-command'
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.16.7@sha256:d85db31e680adb29782aa10d44bf8e9e169a3c3df41d53b1162a325840442625'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.16'
             cache_key_suffix: 'rhel9-2.16'
             # renovate yaml: datasource=pypi
             molecule: '24.6.1'
@@ -111,7 +111,7 @@ jobs:
               - 'python-unversioned-command'
 
           # yamllint disable-line rule:line-length
-          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.15.11@sha256:3134d816655b0f4bb072cb0cd27ac7217ee8e2f0ec0f5569db1bbdd8d9a25bb8'
+          - image: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.15'
             cache_key_suffix: 'rhel9-2.15'
             # renovate yaml: datasource=pypi
             molecule: '6.0.3'


### PR DESCRIPTION
Pinning EEs to minor versions until renovate is able to update patch level updates for images hosted on registry.redhat.io. With pinning to a minor version updates to the image should still be visible, as the digest changes.

The corresponding discussion at renovate can be found here: https://github.com/renovatebot/renovate/discussions/29952#discussioncomment-9992942

A reproducer repository has been implemented at:
https://github.com/sscheib/renovate-reproducer