### PR TITLE
ci: Replacing paths with action dorny/paths-filter

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -43,7 +43,24 @@ env:
   cache_key: 'molecule-cache'
 
 jobs:
+  changes:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      src: '${{ steps.changes.outputs.src }}'
+
+    steps:
+      - uses: 'dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36' # v3.0.2
+        id: 'changes'
+        with:
+          filters: |
+            src:
+              - '**'
+              - '!.github/**'
+              - '.github/workflows/molecule.yml'
+
   molecule:
+    needs: 'changes'
+    if: "needs.changes.outputs.src == 'true'"
     permissions:
       contents: 'write'
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
A bug in the way how paths are detected by GitHub makes the molecule action run on every single pull request. This PR introduces a custom action which allows for filtering on the paths properly.

Reference issue for the filter bug:
https://github.com/actions/runner/issues/2324