### PR TITLE
ci: Fixing workflow runs for renovate and molecule on forked PRs

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -70,12 +70,44 @@ jobs:
               - '!.github/**'
               - '.github/workflows/molecule.yml'
 
-  molecule:
+  check-user-permissions:
+    runs-on: 'ubuntu-latest'
     needs: 'changes'
     if: "needs.changes.outputs.src == 'true'"
+    outputs:
+      require-result: '${{ steps.check-access.outputs.require-result }}'
+    steps:
+      - name: 'Harden Runner'
+        uses: 'step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6' # v2.8.1
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - name: 'Get User Permissions'
+        id: 'check-access'
+        uses: 'actions-cool/check-user-permission@956b2e73cdfe3bcb819bb7225e490cb3b18fd76e' # v2.2.1
+        with:
+          require: 'write'
+          username: '${{ github.triggering_actor }}'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: 'Check User Permission'
+        if: "steps.check-access.outputs.require-result == 'false'"
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.check-access.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+
+  molecule:
+    runs-on: 'ubuntu-latest'
+    needs: 'check-user-permissions'
+    if: "needs.check-user-permissions.outputs.require-result == 'true'"
     permissions:
       contents: 'write'
-    runs-on: 'ubuntu-latest'
     container:
       image: '${{ matrix.container.image }}'
       credentials:
@@ -153,6 +185,9 @@ jobs:
 
       - name: 'Checkout repository'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # v4.1.7
+        with:
+          # check out the pull request's HEAD
+          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Download cache of the previous workflow run'
         uses: 'dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11' # v6

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -89,14 +89,46 @@ jobs:
         run: |
           # renovate: datasource=npm
           npm install renovate@37.421.5
-          npx --yes --package renovate -- renovate-config-validator --strict
+          npx --yes --package renovate -- renovate-config-validator --strict || exit 1
+
+  check-user-permissions:
+    runs-on: 'ubuntu-latest'
+    needs: 'validate-config'
+    outputs:
+      require-result: '${{ steps.check-access.outputs.require-result }}'
+    steps:
+      - name: 'Harden Runner'
+        uses: 'step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6' # v2.8.1
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - name: 'Get User Permissions'
+        id: 'check-access'
+        uses: 'actions-cool/check-user-permission@956b2e73cdfe3bcb819bb7225e490cb3b18fd76e' # v2.2.1
+        with:
+          require: 'write'
+          username: '${{ github.triggering_actor }}'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: 'Check User Permission'
+        if: "steps.check-access.outputs.require-result == 'false'"
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.check-access.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
 
   renovate:
     runs-on: 'ubuntu-latest'
+    needs: 'check-user-permissions'
+    if: "needs.check-user-permissions.outputs.require-result == 'true'"
     permissions:
       contents: 'write'
       pull-requests: 'write'
-    needs: 'validate-config'
     steps:
       - name: 'Harden Runner'
         uses: 'step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6' # v2.8.1
@@ -121,6 +153,9 @@ jobs:
 
       - name: 'Checkout the repository'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # v4.1.7
+        with:
+          # check out the pull request's HEAD
+          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Download cache of the previous workflow run'
         uses: 'dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11' # v6


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

##### SUMMARY

Fixes #188

The molecule and renovate workflows make use of secrets. When a PR is created which involves changes to either the molecule or the renovate workflow, it will fail, as the secrets are inaccessible to the PR.

This commit introduces a new action to check if the person that triggered the PR has write permissions on the repository. If not the workflow will not run.

If a contributor will re-run the failed workflow, it will use the permissions of that contributor and check out the PRs HEAD SHA and run against that.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```plaintext paste below

```
