### PR TITLE
ci: Enabling merge confidence badges for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
-    "docker:pinDigests"
+    "docker:pinDigests",
+    "mergeConfidence:all-badges"
   ],
   "assignees": [
     "sscheib"


### PR DESCRIPTION
##### SUMMARY <!-- markdownlint-disable-line MD041 -->

Enabling [merge confidence](https://docs.renovatebot.com/merge-confidence/) for renovate.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```plaintext paste below

```
