### PR TITLE
ci(renovate): removing registry names from commit messages on container images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -204,6 +204,13 @@
       "patch": {
         "enabled": true
       }
+    },
+    {
+      "description": "Remove container registry names to avoid too long commit message subjects",
+      "matchDatasources": [
+        "docker"
+      ],
+      "commitMessageTopic": "{{{replace '(?:registry(?:\.access)?\.redhat\.(?:io|com)|docker\.io|ghcr\.io)\/' '' depName}}}"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
##### SUMMARY <!-- markdownlint-disable-line MD041 -->

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Continuous Integration (CI) Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```plaintext paste below

```
