### PR TITLE
ci: Run workflows only when relevant and add concurrency

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -4,10 +4,29 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - 'main'
+
+    paths:
+      - '.github/workflows/ansible-lint.yml'
+      - 'defaults/**'
+      - 'files/**'
+      - 'handlers/**'
+      - 'library/**'
+      - 'lookup_plugins/**'
+      - 'meta/**'
+      - 'module_utils/**'
+      - 'molecule/**'
+      - 'tasks/**'
+      - 'templates/**'
+      - 'vars/**'
+
   workflow_dispatch: {}
 
 permissions:
   contents: 'read'
+
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -8,6 +8,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     name: 'Dependency Review'

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -22,6 +22,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build_and_deploy:
     name: 'Build and deploy documentation to GitHub Pages'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,6 +10,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: 'gitleaks'

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -12,6 +12,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   hadolint:
     name: 'hadolint'

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -8,8 +8,11 @@ on:  # yamllint disable-line rule:truthy
       - 'main'
   workflow_dispatch: {}
 
-# Declare default permissions as read only.
 permissions: 'read-all'
+
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   analysis:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -4,10 +4,18 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - 'main'
+    paths:
+      - '**.md'
+      - '.github/workflows/markdown-link-check.yml'
+
   workflow_dispatch: {}
 
 permissions:
   contents: 'read'
+
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -4,7 +4,15 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - 'main'
+    paths:
+      - '**.md'
+      - '.github/workflows/markdownlint.yml'
+
   workflow_dispatch: {}
+
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 permissions:
   contents: 'read'

--- a/.github/workflows/molecule_certified_ees.yml
+++ b/.github/workflows/molecule_certified_ees.yml
@@ -77,6 +77,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   check-secrets:
     name: 'Check if required secrets are available'

--- a/.github/workflows/molecule_community_ees.yml
+++ b/.github/workflows/molecule_community_ees.yml
@@ -62,6 +62,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   molecule-community-ees:
     runs-on: 'ubuntu-22.04'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,6 +27,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 # Adding these as env variables makes it easy to re-use them in different steps and in bash.
 env:
   cache_archive: 'pre-commit_cache.tar.gz'

--- a/.github/workflows/purge_caches.yml
+++ b/.github/workflows/purge_caches.yml
@@ -19,6 +19,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   purge-caches:
     name: 'Purge caches'

--- a/.github/workflows/pyspelling.yml
+++ b/.github/workflows/pyspelling.yml
@@ -9,6 +9,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   pyspelling:
     name: 'pyspelling'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: false
+
 # adding the extra_plugins as environment variables allows renovate to update the versions
 env:
   # renovate dep: datasource=npm depName=@semantic-release/changelog

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,6 +40,10 @@ on:  # yamllint disable-line rule:truthy
 # Declare default permissions as read only
 permissions: 'read-all'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 # Adding these as env variables makes it easy to re-use them in different steps and in bash.
 env:
   # cache for the actual renovate run

--- a/.github/workflows/renovate_configuration_check.yml
+++ b/.github/workflows/renovate_configuration_check.yml
@@ -16,6 +16,10 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   validate-renovate-configuration:
     name: 'Validate renovate configuration'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,6 +16,10 @@ on:  # yamllint disable-line rule:truthy
 # Declare default permissions as read only.
 permissions: 'read-all'
 
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   check-secrets:
     name: 'Check if required secrets are available'


### PR DESCRIPTION
Run the workflows only when they really need to run. E.g. markdownlint should only run when *.md files are changed or the workflow file for markdownlint has been changed.

Additionally, adding concurrency to avoid multiple runs of the same workflow on the same commit. This does not apply to all jobs, e.g. release.yml is excempt from that.

##### SUMMARY <!-- markdownlint-disable-line MD041 -->

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Continuous Integration (CI) Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```plaintext paste below

```
