### PR TITLE
chore: Denying the use of non-breakable words in the line length rule

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -30,6 +30,7 @@ rules:
   key-ordering: 'disable'
   line-length:
     max: 120
+    allow-non-breakable-words: false
   new-line-at-end-of-file: 'enable'
   new-lines:
     type: 'unix'


### PR DESCRIPTION
##### SUMMARY <!-- markdownlint-disable-line MD041 -->

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
- Continuous Integration (CI) Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```plaintext paste below

```
